### PR TITLE
Fix env setup due to youtokenme install issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ ffmpeg
 torch==1.13.1+cu117
 torchaudio==0.13.1+cu117
 torchvision==0.14.1+cu117
+git+https://github.com/gburlet/YouTokenToMe.git@dependencies    # https://github.com/VKCOM/YouTokenToMe/pull/108
 nemo_toolkit[all]


### PR DESCRIPTION
Fixes #12 by referencing an open PR that fixes upstream bug in youtokenme, which is a dependency of nemo_toolkit

Instead of referenced youtokenme version (which does not properly list Cython as a build dependency) use a git version with an open PR for addressing it.